### PR TITLE
Update index.markdown

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -58,7 +58,7 @@ This is a list of my public repositories
 {% raw %}
 <div>
   {% for repository in site.github.public_repositories %}
-    <span>{{ repository.full_name }} </span>
+    <div>{{ repository.full_name }} </div>
   {% endfor %}
 </div>
 {% endraw %}


### PR DESCRIPTION
Replace <span> tags with <div> tags to force list of repositories into a list format, instead of a text blob.
